### PR TITLE
Artist Info Link Button Prototype

### DIFF
--- a/packages/app/app/components/ArtistView/index.tsx
+++ b/packages/app/app/components/ArtistView/index.tsx
@@ -44,10 +44,6 @@ const ArtistView: React.FC<ArtistViewProps> = ({
 
   const isOnTour = () => artist.onTour || false;
 
-  // TODO: remove these
-  // let resourceUrl: string; // used for artist info button
-  // const handleInfoLink = () => window.open(this.makeHref(resourceUrl));
-
   function renderArtistHeader() {
     return (
       <div className={styles.artist_header_overlay}>
@@ -141,14 +137,6 @@ const ArtistView: React.FC<ArtistViewProps> = ({
   }
 
   function renderHeaderBanner() {
-    /* try {
-      //may be able to use a different index from the artist object to create
-      //album info links or something similar
-      resourceUrl = JSON.stringify(artist.releases[0].resourceUrl);
-      console.log("resourceUrl assigned: " + resourceUrl);
-    } catch (e: Exception) {
-      // resourceURL assignment won't work while artist is loading
-    }*/
     return (
       <div
         style={{

--- a/packages/app/app/components/ArtistView/index.tsx
+++ b/packages/app/app/components/ArtistView/index.tsx
@@ -37,9 +37,9 @@ const ArtistView: React.FC<ArtistViewProps> = ({
 }) => {
   const { t }= useTranslation('artist');
   const history = useHistory();
-  
+
   const isLoading = () => artist.loading || false;
-  
+
   const isOnTour = () => artist.onTour || false;
 
   function renderArtistHeader() {
@@ -86,6 +86,18 @@ const ArtistView: React.FC<ArtistViewProps> = ({
                   name={isFavorite ? 'heart' : 'heart outline'}
                   size='big'
                 />
+              </a>
+
+              <a
+                href='#'
+                className={styles.artist_info_button}
+                data-testid='artist-info'
+              >
+                <Icon
+                  name='linkify'
+                  size='big'
+                />
+                Artist Info
               </a>
             </div>
 

--- a/packages/app/app/components/ArtistView/index.tsx
+++ b/packages/app/app/components/ArtistView/index.tsx
@@ -118,14 +118,6 @@ const ArtistView: React.FC<ArtistViewProps> = ({
   }
 
   function renderPopularTracks() {
-    try {
-      /* may be able to use a different index from the artist object to create
-         *album info links or something similar
-         */
-      resourceUrl = JSON.stringify(artist.releases[0].resourceUrl);
-    } catch (e: Exception) {
-      // resourceURL assignment won't work while artist is loading
-    }
     return (
       !isLoading() &&
       artist.topTracks && (
@@ -149,6 +141,14 @@ const ArtistView: React.FC<ArtistViewProps> = ({
   }
 
   function renderHeaderBanner() {
+    try {
+      /* may be able to use a different index from the artist object to create
+      *album info links or something similar
+      */
+      resourceUrl = JSON.stringify(artist.releases[0].resourceUrl);
+    } catch (e: Exception) {
+      // resourceURL assignment won't work while artist is loading
+    }
     return (
       <div
         style={{

--- a/packages/app/app/components/ArtistView/index.tsx
+++ b/packages/app/app/components/ArtistView/index.tsx
@@ -97,7 +97,7 @@ const ArtistView: React.FC<ArtistViewProps> = ({
                   name='linkify'
                   size='big'
                 />
-                Artist Info
+                {t('info')}
               </a>
             </div>
 

--- a/packages/app/app/components/ArtistView/index.tsx
+++ b/packages/app/app/components/ArtistView/index.tsx
@@ -42,9 +42,7 @@ const ArtistView: React.FC<ArtistViewProps> = ({
 
   const isOnTour = () => artist.onTour || false;
 
-  // TODO: make this open in default browser, not within appplication
   // use open npm package? https://www.npmjs.com/package/open
-  // TODO: pull link from artist info or somewhere like that
   let resourceUrl: string; // used for artist info button
   const handleInfoLink = () => window.open(resourceUrl);
 

--- a/packages/app/app/components/ArtistView/index.tsx
+++ b/packages/app/app/components/ArtistView/index.tsx
@@ -43,8 +43,10 @@ const ArtistView: React.FC<ArtistViewProps> = ({
   const isOnTour = () => artist.onTour || false;
 
   // TODO: make this open in default browser, not within appplication
+  // use open npm package? https://www.npmjs.com/package/open
   // TODO: pull link from artist info or somewhere like that
-  const handleInfoLink = () => window.open('www.bandcamp.com');
+  let resourceUrl: string; // used for artist info button
+  const handleInfoLink = () => window.open(resourceUrl);
 
   function renderArtistHeader() {
     return (
@@ -116,6 +118,14 @@ const ArtistView: React.FC<ArtistViewProps> = ({
   }
 
   function renderPopularTracks() {
+    try {
+      /* may be able to use a different index from the artist object to create
+         *album info links or something similar
+         */
+      resourceUrl = JSON.stringify(artist.releases[0].resourceUrl);
+    } catch (e: Exception) {
+      // resourceURL assignment won't work while artist is loading
+    }
     return (
       !isLoading() &&
       artist.topTracks && (

--- a/packages/app/app/components/ArtistView/index.tsx
+++ b/packages/app/app/components/ArtistView/index.tsx
@@ -24,6 +24,7 @@ type ArtistViewProps = {
   albumInfoSearch: (albumId: any, releaseType: any, release: any) => Promise<void>;
   removeFavoriteArtist: React.MouseEventHandler;
   addFavoriteArtist: React.MouseEventHandler;
+  handleArtistInfoClick: () => void;
 }
 
 const ArtistView: React.FC<ArtistViewProps> = ({
@@ -33,7 +34,8 @@ const ArtistView: React.FC<ArtistViewProps> = ({
   artistInfoSearchByName,
   albumInfoSearch,
   removeFavoriteArtist,
-  addFavoriteArtist
+  addFavoriteArtist,
+  handleArtistInfoClick
 }) => {
   const { t }= useTranslation('artist');
   const history = useHistory();
@@ -42,9 +44,9 @@ const ArtistView: React.FC<ArtistViewProps> = ({
 
   const isOnTour = () => artist.onTour || false;
 
-  // use open npm package? https://www.npmjs.com/package/open
-  let resourceUrl: string; // used for artist info button
-  const handleInfoLink = () => window.open(resourceUrl);
+  // TODO: remove these
+  // let resourceUrl: string; // used for artist info button
+  // const handleInfoLink = () => window.open(this.makeHref(resourceUrl));
 
   function renderArtistHeader() {
     return (
@@ -96,7 +98,7 @@ const ArtistView: React.FC<ArtistViewProps> = ({
                 href='#'
                 className={styles.artist_info_button}
                 data-testid='artist-info'
-                onClick={handleInfoLink}
+                onClick={handleArtistInfoClick}
               >
                 <Icon
                   name='linkify'
@@ -139,14 +141,14 @@ const ArtistView: React.FC<ArtistViewProps> = ({
   }
 
   function renderHeaderBanner() {
-    try {
-      /* may be able to use a different index from the artist object to create
-      *album info links or something similar
-      */
+    /* try {
+      //may be able to use a different index from the artist object to create
+      //album info links or something similar
       resourceUrl = JSON.stringify(artist.releases[0].resourceUrl);
+      console.log("resourceUrl assigned: " + resourceUrl);
     } catch (e: Exception) {
       // resourceURL assignment won't work while artist is loading
-    }
+    }*/
     return (
       <div
         style={{

--- a/packages/app/app/components/ArtistView/index.tsx
+++ b/packages/app/app/components/ArtistView/index.tsx
@@ -42,6 +42,10 @@ const ArtistView: React.FC<ArtistViewProps> = ({
 
   const isOnTour = () => artist.onTour || false;
 
+  // TODO: make this open in default browser, not within appplication
+  // TODO: pull link from artist info or somewhere like that
+  const handleInfoLink = () => window.open('www.bandcamp.com');
+
   function renderArtistHeader() {
     return (
       <div className={styles.artist_header_overlay}>
@@ -92,6 +96,7 @@ const ArtistView: React.FC<ArtistViewProps> = ({
                 href='#'
                 className={styles.artist_info_button}
                 data-testid='artist-info'
+                onClick={handleInfoLink}
               >
                 <Icon
                   name='linkify'

--- a/packages/app/app/components/ArtistView/index.tsx
+++ b/packages/app/app/components/ArtistView/index.tsx
@@ -95,7 +95,7 @@ const ArtistView: React.FC<ArtistViewProps> = ({
               >
                 <Icon
                   name='linkify'
-                  size='big'
+                  size='large'
                 />
                 {t('info')}
               </a>

--- a/packages/app/app/components/ArtistView/styles.scss
+++ b/packages/app/app/components/ArtistView/styles.scss
@@ -108,4 +108,12 @@
       display: none;
     }
   }
+
+  .artist_info_button {
+    @include roundCorners;
+    align-items: center;
+    justify-content: center;
+    display: flex;
+    //float: right;
+  }
 }

--- a/packages/app/app/components/ArtistView/styles.scss
+++ b/packages/app/app/components/ArtistView/styles.scss
@@ -110,10 +110,9 @@
   }
 
   .artist_info_button {
-    @include roundCorners;
     align-items: center;
     justify-content: center;
     display: flex;
-    //float: right;
+    font-size: 18px;
   }
 }

--- a/packages/app/app/containers/ArtistViewContainer/hooks.ts
+++ b/packages/app/app/containers/ArtistViewContainer/hooks.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useParams } from 'react-router';
 import _ from 'lodash';
+import electron from 'electron';
 
 import * as QueueActions from '../../actions/queue';
 import * as SearchActions from '../../actions/search';
@@ -41,11 +42,20 @@ export const useArtistViewProps = () => {
 
   const addFavoriteArtist = useCallback(async () => {
     dispatch(FavoritesActions.addFavoriteArtist(artist));
+    // console.log("addFavoriteArtist called in ArtistViewContainer/hooks");
   }, [artist, dispatch]);
 
   const removeFavoriteArtist = useCallback(async () => {
     dispatch(FavoritesActions.removeFavoriteArtist(artist));
+    // console.log("removeFavoriteArtist called in ArtistViewContainer/hooks");
   }, [artist, dispatch]);
+
+  const handleExternal = (link: string) => {
+    // console.log("handleExternal in hooks");
+    link && link.length && electron.shell.openExternal(link);
+  };
+
+  const handleArtistInfoClick = () => handleExternal('https://google.com');
 
   return {
     artist,
@@ -54,6 +64,7 @@ export const useArtistViewProps = () => {
     artistInfoSearchByName,
     albumInfoSearch,
     removeFavoriteArtist,
-    addFavoriteArtist
+    addFavoriteArtist,
+    handleArtistInfoClick
   };
 };

--- a/packages/app/app/containers/ArtistViewContainer/hooks.ts
+++ b/packages/app/app/containers/ArtistViewContainer/hooks.ts
@@ -42,20 +42,18 @@ export const useArtistViewProps = () => {
 
   const addFavoriteArtist = useCallback(async () => {
     dispatch(FavoritesActions.addFavoriteArtist(artist));
-    // console.log("addFavoriteArtist called in ArtistViewContainer/hooks");
   }, [artist, dispatch]);
 
   const removeFavoriteArtist = useCallback(async () => {
     dispatch(FavoritesActions.removeFavoriteArtist(artist));
-    // console.log("removeFavoriteArtist called in ArtistViewContainer/hooks");
   }, [artist, dispatch]);
 
+  const handleArtistInfoClick = () => handleExternal(artist.releases[0].resourceUrl);
+  
   const handleExternal = (link: string) => {
-    // console.log("handleExternal in hooks");
     link && link.length && electron.shell.openExternal(link);
   };
 
-  const handleArtistInfoClick = () => handleExternal('https://google.com');
 
   return {
     artist,

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -32,7 +32,8 @@
     "queue": "Add all tracks to queue",
     "similar": "Similar artists",
     "title": "Title",
-    "tour": "On tour"
+    "tour": "On tour",
+    "info": "Artist Info"
   },
   "dashboard": {
     "add-all": "Add all",


### PR DESCRIPTION
Artist info links are currently working for Bandcamp and iTunesMusic. The "Artist Info" button will open the artist's Bandcamp/iTunes page when clicked. It still needs work for the other metadata providers, but the core functionality is in place.

![image](https://user-images.githubusercontent.com/47801590/140860776-a3add994-9c96-43c6-b9b8-2a54e844b64d.png)

